### PR TITLE
update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ function overrideWindow() {
 function overrideFileReader() {
   const FileReader = function () { };
   FileReader.prototype.readAsDataURL = function (buffer) {
-    console.log(`buffer`, buffer)
     this.onload({
       target: {
         result: 'data:image/' + imageType(buffer) + ';base64,' + buffer.toString('base64')

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// const jsdom = require('jsdom');
 const canvas = require('canvas');
 const imageType = require('image-type');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-resemble",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Image analysis and comparison with HTML5",
   "main": "index.js",
   "keywords": [
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/ddo/node-resemble",
   "dependencies": {
-    "canvas": "^1.1.5",
-    "image-type": "^1.0.0",
-    "resemblejs": "1.1.3"
+    "canvas": "^1.5.0",
+    "image-type": "^2.1.0",
+    "resemblejs": "^2.2.2"
   }
 }


### PR DESCRIPTION
I've had to set the overrides on `global` as Resemble now seems to use the `Image` and `FileReader` that comes with the browser.

Wasn't sure what version bump you'd like for the package... but i've gone for major to match `resemblejs`.

fixes #2 
